### PR TITLE
Fix fader controls

### DIFF
--- a/src/app/Components/ControlPanel/Fader.tsx
+++ b/src/app/Components/ControlPanel/Fader.tsx
@@ -74,7 +74,7 @@ export const Fader = (props: {
 	onChange: (value: number) => void
 }) => (
 	<Slider
-		disabled={props.value === false}
+		disabled={props.disabled}
 		onChange={value => (!props.disabled ? props.onChange(value) : false)}
 		value={props.value !== false ? props.value : null}
 		radius={'lg'}
@@ -101,6 +101,7 @@ export const Fader = (props: {
 				width: 1,
 			},
 			thumb: {
+				display: 'block',
 				height: props.disabled ? '1em' : '2em',
 				width: props.disabled ? '0.5em' : '1em',
 				backgroundColor: 'white',

--- a/src/app/Components/ControlPanel/PresetFaders.tsx
+++ b/src/app/Components/ControlPanel/PresetFaders.tsx
@@ -16,7 +16,7 @@ export const PresetFaders = (props: { faders: Array<DatabaseFader> }) => {
 				{props.faders.map(fader => {
 					const faderString = faderArrayToString(fader.type, fader.channel, deviceType)
 					return (
-						<>
+						<div key={fader.id}>
 							<Group position="left" mt="md">
 								<Title order={4} key={'title' + fader.id}>
 									{fader.name}
@@ -51,7 +51,7 @@ export const PresetFaders = (props: { faders: Array<DatabaseFader> }) => {
 									})
 								}
 							/>
-						</>
+						</div>
 					)
 				})}
 			</>


### PR DESCRIPTION
* Uses mantine disabled rather than tracking ourselves separately

Closes #103 


## Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

## Test Checklist 

### Basics

- [x] Boots with a pre-existing database from the previous release, uploaded using the interface
- [x] Boots without a database, successfully creating its own 
- [x] Reboots when reboot clicked
- [x] Quits when quit clicked

### Presets

- [x] Presets can be added
- [x] Presets can be removed
- [x] Presets can be renamed, and this is reflected on the control panel
- [x] Presets can be disabled, and they are hidden from the control panel
- [x] Presets can be enabled, and they are shown in the control panel
- [x] Preset colors can be changed, and this is shown in the control panel
- [x] Preset sort order is maintained

### Folders


