### PR TITLE
Min width & height cuts off menu bar on raspian

### DIFF
--- a/src/electron/createMainWindow.ts
+++ b/src/electron/createMainWindow.ts
@@ -14,8 +14,6 @@ export default (startPath: string, fullscreen?: boolean): BrowserWindow => {
 	const window = new BrowserWindow({
 		height: 519, // Equates to 480 when you knock off the menu bar
 		width: 816, // Equates to 800 when you knock off the menu bar
-		minWidth: 816,
-		minHeight: 519,
 		fullscreen: process.env.FULLSCREEN && process.env.FULLSCREEN == 'true' ? true : fullscreen ?? false, // Environment variable is the priority, followed by the variable passed to the function
 		title: 'Paradise',
 		icon: path.join(__dirname, '/../../icon/icon.png'),


### PR DESCRIPTION

## Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

## Test Checklist 

### Basics

- [ ] Boots with a pre-existing database from the previous release, uploaded using the interface
- [ ] Boots without a database, successfully creating its own 
- [ ] Reboots when reboot clicked
- [ ] Quits when quit clicked

### Presets

- [ ] Presets can be added
- [ ] Presets can be removed
- [ ] Presets can be renamed, and this is reflected on the control panel
- [ ] Presets can be disabled, and they are hidden from the control panel
- [ ] Presets can be enabled, and they are shown in the control panel
- [ ] Preset colors can be changed, and this is shown in the control panel
- [ ] Preset sort order is maintained

### Folders


