### PR TITLE
Set screensaver to idle default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paradisepi",
-  "version": "2.0.0-beta5",
+  "version": "2.0.0-beta6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "paradisepi",
-      "version": "2.0.0-beta5",
+      "version": "2.0.0-beta6",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@emotion/react": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paradisepi",
-  "version": "2.0.0-beta5",
+  "version": "2.0.0-beta6",
   "description": "Raspberry Pi based sACN lighting/OSC sound facility control panel",
   "main": ".webpack/main",
   "scripts": {

--- a/src/app/Components/ScreenSaver.tsx
+++ b/src/app/Components/ScreenSaver.tsx
@@ -57,6 +57,6 @@ export const ScreenSaver = (props: { children: React.ReactNode }) => {
 		state.database ? state.database.config.general.timeoutTime : defaultTimeoutTime
 	)
 	if (timeoutTime < 4000) timeoutTime = 4000 //Set a lower limit of 4 seconds otherwise it all gets a bit silly really
-	const showScreensaver = useIdle(timeoutTime, { initialState: false })
+	const showScreensaver = useIdle(timeoutTime, { initialState: true })
 	return <>{showScreensaver ? <ScreensaverView /> : props.children}</>
 }


### PR DESCRIPTION
As @cherry-john has discovered and explained, this is a trade-off as we are quite limited in our options.  It's my view that we should default to the screensaver so that in the case of an overnight power-outage we can recover to the screensaver rather than risk burn-in. This puts screen safety first