### PR TITLE
Allow presets to be recalled using the admin interface

### DIFF
--- a/src/app/Pages/Admin/Presets.tsx
+++ b/src/app/Pages/Admin/Presets.tsx
@@ -26,6 +26,7 @@ import { FaCheck } from '@react-icons/all-files/fa/FaCheck'
 import { FaFolder } from '@react-icons/all-files/fa/FaFolder'
 import { FaGripVertical } from '@react-icons/all-files/fa/FaGripVertical'
 import { FaPencilAlt } from '@react-icons/all-files/fa/FaPencilAlt'
+import { FaPlay } from '@react-icons/all-files/fa/FaPlay'
 import { FaPlus } from '@react-icons/all-files/fa/FaPlus'
 import { FaRecycle } from '@react-icons/all-files/fa/FaRecycle'
 import { FaRegClock } from '@react-icons/all-files/fa/FaRegClock'
@@ -152,6 +153,16 @@ export const PresetsConfigurationPage = () => {
 							title="Visible"
 							{...form.getInputProps(`presets.${index}.enabled`, { type: 'checkbox' })}
 						/>
+					</td>
+					<td style={{ width: 0 }}>
+						<ActionIcon
+							variant="transparent"
+							title="Recall"
+							disabled={saveByUserNeeded}
+							onClick={() => ApiCall.get('/presets/recall/' + form.values.presets[index].id, {})}
+						>
+							<FaPlay />
+						</ActionIcon>
 					</td>
 					<td style={{ width: 0 }}>
 						<Modal
@@ -387,6 +398,7 @@ export const PresetsConfigurationPage = () => {
 									<th>Name</th>
 									<th>Folder</th>
 									<th>Visible</th>
+									<th></th>
 									<th></th>
 									<th></th>
 									<th></th>


### PR DESCRIPTION
## Changelog

Presets can be recalled using the admin interface, to speed up editing

## Checklist

- [ ] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

## Test Checklist 

### Basics

- [ ] Boots with a pre-existing database from the previous release, uploaded using the interface
- [ ] Boots without a database, successfully creating its own 
- [ ] Reboots when reboot clicked
- [ ] Quits when quit clicked

### Presets/Faders/Folders

- [ ] Presets/Faders/Folders can be added
- [ ] Presets/Faders/Folders can be removed
- [ ] Presets/Faders/Folders can be renamed, and this is reflected on the control panel
- [ ] Presets/Folders can be disabled, and they are hidden from the control panel
- [ ] Presets/Faders/Folders can be enabled, and they are shown in the control panel
- [ ] Preset/Folders colors can be changed, and this is shown in the control panel
- [ ] Preset/Faders/Folders sort order is maintained
- [ ] Presets can be triggered by HTTP requests

### Preset Triggers

- [ ] Presets can be triggered by HTTP requests
- [ ] Time clock triggers recall presets successfully
- [ ] Time clock triggers do not recall when device locked

### Preset Types

#### sACN

- [ ] sACN can be enabled/disabled
- [ ] sACN data is output successfully

#### OSC

- [ ] OSC can be enabled/disabled
- [ ] OSC data is output successfully
- [ ] X32 Faders are functional

#### HTTP

- [ ] HTTP requests are made successfully

#### Macros

- [ ] Macros are triggered successfully
- [ ] Macros can trigger other macros
- [ ] Lock macro functions


