### PR TITLE
Update typo in documentation

### DIFF
--- a/docs/docs/user-guide/deploying/pi.md
+++ b/docs/docs/user-guide/deploying/pi.md
@@ -69,7 +69,7 @@ Add ` -nocursor` to the end of the line. It should now be `xserver-command = X -
 
 This will popup every 24hrs to let you know that apt packages can be updated.
 
-To disbale it, right click on the menu bar in Rapsberry Pi OS and select the `preferences` button for updater. This will allow you to set the check frequency to 1000 hours (41 days) and you can then click "remove" to hide it from the taskbar as well
+To disable it, right click on the menu bar in Raspberry Pi OS and select the `preferences` button for updater. This will allow you to set the check frequency to 1000 hours (41 days) and you can then click "remove" to hide it from the taskbar as well
 
 ## Updating
 


### PR DESCRIPTION
## Changelog

Updated typo in documentation 

## Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

## Test Checklist 

### Basics

- [ ] Boots with a pre-existing database from the previous release, uploaded using the interface
- [ ] Boots without a database, successfully creating its own 
- [ ] Reboots when reboot clicked
- [ ] Quits when quit clicked

### Presets/Faders/Folders

- [ ] Presets/Faders/Folders can be added
- [ ] Presets/Faders/Folders can be removed
- [ ] Presets/Faders/Folders can be renamed, and this is reflected on the control panel
- [ ] Presets/Folders can be disabled, and they are hidden from the control panel
- [ ] Presets/Faders/Folders can be enabled, and they are shown in the control panel
- [ ] Preset/Folders colors can be changed, and this is shown in the control panel
- [ ] Preset/Faders/Folders sort order is maintained
- [ ] Presets can be triggered by HTTP requests

### Preset Triggers

- [ ] Presets can be triggered by HTTP requests
- [ ] Time clock triggers recall presets successfully
- [ ] Time clock triggers do not recall when device locked

### Preset Types

#### sACN

- [ ] sACN can be enabled/disabled
- [ ] sACN data is output successfully

#### OSC

- [ ] OSC can be enabled/disabled
- [ ] OSC data is output successfully
- [ ] X32 Faders are functional

#### HTTP

- [ ] HTTP requests are made successfully

#### Macros

- [ ] Macros are triggered successfully
- [ ] Macros can trigger other macros
- [ ] Lock macro functions


